### PR TITLE
Add memory retrieval environment and training example

### DIFF
--- a/docs/guides/memory_retrieval.md
+++ b/docs/guides/memory_retrieval.md
@@ -1,0 +1,32 @@
+# Training the Obsidian Memory Agent with NeMo RL
+
+This guide explains how to train the Obsidian memory agent on a retrieval task using NeMo RL's GRPO algorithm.
+
+## Dataset Format
+The training dataset should be a JSON list where each element contains the question, the expected answer and a snapshot of the agent's memory.
+
+```json
+[
+  {
+    "question": "What is my age?",
+    "answer": "age: 34",
+    "task": "retrieval",
+    "static_memory": "{\"guideline\":\"...\", ...}",
+    "persona": "Elena Müller",
+    "fact": "age: 34"
+  }
+]
+```
+
+`static_memory` is the serialized content of the agent's memory directory that will be instantiated before each episode.
+
+## Running Training
+1. Place your dataset JSON somewhere accessible.
+2. Edit `examples/configs/grpo_memory_retrieval.yaml` and set `data.dataset_path` to the location of the dataset.
+3. Launch training with `uv`:
+
+```bash
+uv run examples/run_memory_retrieval.py --config examples/configs/grpo_memory_retrieval.yaml
+```
+
+The script loads the `Qwen/Qwen3-4B` model and trains it with GRPO. Checkpoints will be written to `results/grpo-memory` and logs to `logs/`.

--- a/examples/configs/grpo_memory_retrieval.yaml
+++ b/examples/configs/grpo_memory_retrieval.yaml
@@ -1,0 +1,126 @@
+# GRPO configuration for memory retrieval training
+
+grpo:
+  num_prompts_per_step: 8
+  num_generations_per_prompt: 4
+  max_rollout_turns: 6
+  max_num_steps: 1000000
+  normalize_rewards: true
+  use_leave_one_out_baseline: true
+  val_period: 10
+  val_at_start: false
+  max_val_samples: 64
+  val_batch_size: 64
+
+loss_fn:
+  reference_policy_kl_penalty: 0.01
+  ratio_clip_min: 0.2
+  ratio_clip_max: 0.2
+  use_on_policy_kl_approximation: false
+  use_importance_sampling_correction: false
+  token_level_loss: true
+
+checkpointing:
+  enabled: true
+  checkpoint_dir: "results/grpo-memory"
+  metric_name: "val_reward"
+  higher_is_better: true
+  keep_top_k: 3
+  save_period: 10
+
+policy:
+  model_name: "Qwen/Qwen3-4B"
+  tokenizer:
+    name: ${policy.model_name}
+  train_global_batch_size: 64
+  train_micro_batch_size: 4
+  generation_batch_size: 8
+  logprob_batch_size: 4
+  max_total_sequence_length: 512
+  precision: "bfloat16"
+  fsdp_offload_enabled: false
+  activation_checkpointing_enabled: false
+  dtensor_cfg:
+    enabled: true
+    cpu_offload: False
+    sequence_parallel: false
+    activation_checkpointing: false
+    tensor_parallel_size: 1
+    context_parallel_size: 1
+    custom_parallel_plan: null
+  dynamic_batching:
+    enabled: True
+    train_mb_tokens: ${mul:${policy.max_total_sequence_length}, ${policy.train_micro_batch_size}}
+    logprob_mb_tokens: ${mul:${policy.max_total_sequence_length}, ${policy.logprob_batch_size}}
+    sequence_length_round: 64
+  make_sequence_length_divisible_by: ${policy.dtensor_cfg.tensor_parallel_size}
+  max_grad_norm: 1.0
+  optimizer:
+    name: "torch.optim.AdamW"
+    kwargs:
+      lr: 5.0e-6
+      weight_decay: 0.01
+      betas: [0.9, 0.999]
+      eps: 1e-8
+      foreach: False
+      fused: False
+  scheduler:
+    - name: "torch.optim.lr_scheduler.LinearLR"
+      kwargs:
+        start_factor: 0.1
+        end_factor: 1.0
+        total_iters: 50
+    - name: "torch.optim.lr_scheduler.ConstantLR"
+      kwargs:
+        factor: 1.0
+        total_iters: 10000000000
+    - milestones: [50]
+  generation:
+    backend: "vllm"
+    max_new_tokens: ${policy.max_total_sequence_length}
+    temperature: 1.0
+    top_p: 1.0
+    top_k: null
+    stop_token_ids: null
+    stop_strings: null
+    vllm_cfg:
+      async_engine: false
+      precision: ${policy.precision}
+      tensor_parallel_size: 1
+      pipeline_parallel_size: 1
+      gpu_memory_utilization: 0.6
+      max_model_len: ${policy.max_total_sequence_length}
+    colocated:
+      enabled: true
+      resources:
+        gpus_per_node: null
+        num_nodes: null
+
+data:
+  dataset_path: "path/to/dataset.json"
+  max_input_seq_length: ${policy.max_total_sequence_length}
+  prompt_file: null
+  system_prompt_file: null
+  dataset_name: "MemoryRetrieval"
+
+env:
+  memory_retrieval:
+    max_turns: 6
+
+logger:
+  log_dir: "logs"
+  num_val_samples_to_print: 0
+  wandb_enabled: false
+  tensorboard_enabled: false
+  monitor_gpus: true
+  wandb:
+    project: "memory-retrieval"
+    name: "memory-retrieval"
+  tensorboard: {}
+  gpu_monitoring:
+    collection_interval: 10
+    flush_interval: 10
+
+cluster:
+  gpus_per_node: 1
+  num_nodes: 1

--- a/examples/run_memory_retrieval.py
+++ b/examples/run_memory_retrieval.py
@@ -1,0 +1,206 @@
+import argparse
+import os
+import pprint
+from collections import defaultdict
+from typing import Any, Optional, cast
+
+import torch
+from omegaconf import OmegaConf
+from transformers import PreTrainedTokenizerBase
+
+from nemo_rl.algorithms.grpo import MasterConfig, grpo_train, setup
+from nemo_rl.algorithms.utils import get_tokenizer
+from nemo_rl.data.datasets import AllTaskProcessedDataset
+from nemo_rl.data.interfaces import (
+    DatumSpec,
+    LLMMessageLogType,
+    TaskDataProcessFnCallable,
+    TaskDataSpec,
+)
+from nemo_rl.distributed.ray_actor_environment_registry import get_actor_python_env
+from nemo_rl.distributed.virtual_cluster import init_ray
+from nemo_rl.environments.interfaces import EnvironmentInterface
+from nemo_rl.models.generation import configure_generation_config
+from nemo_rl.utils.config import load_config, parse_hydra_overrides
+from nemo_rl.utils.logger import get_next_experiment_dir
+
+from nemo_rl.data.hf_datasets.memory_retrieval_dataset import MemoryRetrievalDataset
+from nemo_rl.environments.memory_retrieval_environment import MemoryRetrievalEnvironment
+
+OmegaConf.register_new_resolver("mul", lambda a, b: a * b)
+
+TokenizerType = PreTrainedTokenizerBase
+
+
+def parse_args() -> tuple[argparse.Namespace, list[str]]:
+    parser = argparse.ArgumentParser(description="Run GRPO training for memory retrieval")
+    parser.add_argument("--config", type=str, default=None, help="Path to YAML config file")
+    args, overrides = parser.parse_known_args()
+    return args, overrides
+
+
+def memory_retrieval_processor(
+    datum_dict: dict[str, Any],
+    task_data_spec: TaskDataSpec,
+    tokenizer: TokenizerType,
+    max_seq_length: int,
+    idx: int,
+) -> DatumSpec:
+    question = datum_dict["messages"][0]["content"]
+    extra_env_info = {
+        "answer": datum_dict["answer"],
+        "static_memory": datum_dict.get("static_memory", ""),
+    }
+
+    message_log: LLMMessageLogType = []
+
+    if task_data_spec.system_prompt:
+        sys_prompt: dict[str, str | torch.Tensor] = {
+            "role": "system",
+            "content": task_data_spec.system_prompt,
+        }
+        sys = tokenizer.apply_chat_template(
+            [cast(dict[str, str], sys_prompt)],
+            tokenize=False,
+            add_generation_prompt=False,
+            add_special_tokens=False,
+        )
+        sys_prompt["token_ids"] = tokenizer(sys, return_tensors="pt")["input_ids"][0]
+        message_log.append(sys_prompt)
+
+    if task_data_spec.prompt:
+        question = task_data_spec.prompt.format(question)
+    user_message = {"role": "user", "content": question}
+    message = tokenizer.apply_chat_template(
+        [user_message],
+        tokenize=False,
+        add_generation_prompt=True,
+        add_special_tokens=False,
+    )
+    user_message["token_ids"] = tokenizer(message, return_tensors="pt")["input_ids"][0]
+    user_message["content"] = message
+    message_log.append(user_message)
+
+    length = sum(len(m["token_ids"]) for m in message_log)
+    loss_multiplier = 1.0
+    if length > max_seq_length:
+        for m in message_log:
+            m["token_ids"] = m["token_ids"][: min(4, max_seq_length // len(message_log))]
+        loss_multiplier = 0.0
+
+    output: DatumSpec = {
+        "message_log": message_log,
+        "length": length,
+        "extra_env_info": extra_env_info,
+        "loss_multiplier": loss_multiplier,
+        "idx": idx,
+        "task_name": datum_dict.get("task_name", "memory_retrieval"),
+    }
+    return output
+
+
+def setup_data(
+    tokenizer: TokenizerType,
+    data_config: dict,
+    env_configs: dict[str, Any],
+) -> tuple[
+    AllTaskProcessedDataset,
+    Optional[AllTaskProcessedDataset],
+    dict[str, EnvironmentInterface],
+    dict[str, EnvironmentInterface],
+]:
+    print("\n▶ Setting up data...")
+    dataset_obj = MemoryRetrievalDataset(data_config["dataset_path"])
+    task_spec = dataset_obj.task_spec
+
+    task_data_processors: dict[str, tuple[TaskDataSpec, TaskDataProcessFnCallable]] = {
+        "memory_retrieval": (task_spec, memory_retrieval_processor)
+    }
+
+    env = MemoryRetrievalEnvironment.options(  # type: ignore
+        runtime_env={
+            "py_executable": get_actor_python_env(
+                "nemo_rl.environments.memory_retrieval_environment.MemoryRetrievalEnvironment"
+            ),
+            "env_vars": dict(os.environ),
+        }
+    ).remote(env_configs["memory_retrieval"])
+
+    dataset = AllTaskProcessedDataset(
+        dataset_obj.formatted_ds["train"],
+        tokenizer,
+        task_spec,
+        task_data_processors,
+        max_seq_length=data_config["max_input_seq_length"],
+    )
+
+    val_dataset = None
+
+    task_to_env: dict[str, EnvironmentInterface] = defaultdict(lambda: env)
+    task_to_env["memory_retrieval"] = env
+    return dataset, val_dataset, task_to_env, task_to_env
+
+
+def main() -> None:
+    args, overrides = parse_args()
+
+    if not args.config:
+        args.config = os.path.join(os.path.dirname(__file__), "configs", "grpo_memory_retrieval.yaml")
+
+    config = load_config(args.config)
+    print(f"Loaded configuration from: {args.config}")
+
+    if overrides:
+        print(f"Overrides: {overrides}")
+        config = parse_hydra_overrides(config, overrides)
+
+    config: MasterConfig = OmegaConf.to_container(config, resolve=True)
+    print("Applied CLI overrides")
+
+    print("Final config:")
+    pprint.pprint(config)
+
+    config["logger"]["log_dir"] = get_next_experiment_dir(config["logger"]["log_dir"])
+    print(f"📊 Using log directory: {config['logger']['log_dir']}")
+    if config["checkpointing"]["enabled"]:
+        print(f"📊 Using checkpoint directory: {config['checkpointing']['checkpoint_dir']}")
+
+    init_ray()
+
+    tokenizer = get_tokenizer(config["policy"]["tokenizer"])
+    assert config["policy"]["generation"] is not None
+    config["policy"]["generation"] = configure_generation_config(config["policy"]["generation"], tokenizer)
+
+    dataset, val_dataset, task_to_env, val_task_to_env = setup_data(tokenizer, config["data"], config["env"])
+
+    (
+        policy,
+        policy_generation,
+        cluster,
+        dataloader,
+        val_dataloader,
+        loss_fn,
+        logger,
+        checkpointer,
+        grpo_state,
+        master_config,
+    ) = setup(config, tokenizer, dataset, val_dataset)
+
+    grpo_train(
+        policy,
+        policy_generation,
+        dataloader,
+        val_dataloader,
+        tokenizer,
+        loss_fn,
+        task_to_env,
+        val_task_to_env,
+        logger,
+        checkpointer,
+        grpo_state,
+        master_config,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/nemo_rl/data/hf_datasets/__init__.py
+++ b/nemo_rl/data/hf_datasets/__init__.py
@@ -20,6 +20,7 @@ from nemo_rl.data.hf_datasets.openmathinstruct2 import OpenMathInstruct2Dataset
 from nemo_rl.data.hf_datasets.prompt_response_dataset import (
     PromptResponseDataset,
 )
+from nemo_rl.data.hf_datasets.memory_retrieval_dataset import MemoryRetrievalDataset
 from nemo_rl.data.hf_datasets.squad import SquadDataset
 
 __all__ = [
@@ -28,6 +29,7 @@ __all__ = [
     "OasstDataset",
     "OpenMathInstruct2Dataset",
     "PromptResponseDataset",
+    "MemoryRetrievalDataset",
     "SquadDataset",
     "COMMON_CHAT_TEMPLATES",
 ]

--- a/nemo_rl/data/hf_datasets/memory_retrieval_dataset.py
+++ b/nemo_rl/data/hf_datasets/memory_retrieval_dataset.py
@@ -1,0 +1,27 @@
+from typing import Any
+
+from datasets import load_dataset
+
+from nemo_rl.data.interfaces import TaskDataSpec
+
+
+def _format(example: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "messages": [{"role": "user", "content": example["question"]}],
+        "answer": example["answer"],
+        "static_memory": example.get("static_memory", ""),
+        "task_name": "memory_retrieval",
+    }
+
+
+class MemoryRetrievalDataset:
+    """Load a JSON dataset for the memory retrieval task."""
+
+    def __init__(self, path: str):
+        ds = load_dataset("json", data_files=path)["train"]
+        formatted = ds.map(_format, remove_columns=ds.column_names)
+        self.formatted_ds = {"train": formatted, "validation": None}
+        self.task_spec = TaskDataSpec(
+            task_name="memory_retrieval",
+            system_prompt_file="obsidian-agent/agent/system_prompt.txt",
+        )

--- a/nemo_rl/environments/__init__.py
+++ b/nemo_rl/environments/__init__.py
@@ -1,0 +1,9 @@
+from .games.sliding_puzzle import SlidingPuzzleEnv
+from .math_environment import MathEnvironment
+from .memory_retrieval_environment import MemoryRetrievalEnvironment
+
+__all__ = [
+    "SlidingPuzzleEnv",
+    "MathEnvironment",
+    "MemoryRetrievalEnvironment",
+]

--- a/nemo_rl/environments/memory_retrieval_environment.py
+++ b/nemo_rl/environments/memory_retrieval_environment.py
@@ -1,0 +1,140 @@
+import json
+import os
+import tempfile
+from typing import Any, Optional, TypedDict
+
+import ray
+import torch
+
+from agent.engine import execute_sandboxed_code
+from agent.settings import MAX_TOOL_TURNS, SANDBOX_TIMEOUT
+from agent.utils import extract_python_code, extract_reply
+from data.schemas.kb import Fact
+from training.reward import get_reward
+
+from nemo_rl.distributed.batched_data_dict import BatchedDataDict
+from nemo_rl.environments.interfaces import EnvironmentInterface, EnvironmentReturn
+
+
+class MemoryRetrievalEnvConfig(TypedDict, total=False):
+    max_turns: int
+
+
+class MemoryRetrievalMetadata(TypedDict, total=False):
+    answer: str
+    static_memory: str
+    num_turns: int
+    memory_dir: str
+    _tmpdir: Any
+
+
+@ray.remote
+class MemoryRetrievalEnvironment(EnvironmentInterface):
+    """Multi-turn environment for the Obsidian memory agent."""
+
+    def __init__(self, cfg: Optional[MemoryRetrievalEnvConfig] = None):
+        cfg = cfg or {}
+        self.max_turns = cfg.get("max_turns", MAX_TOOL_TURNS)
+
+    # ------------------------------------------------------------------
+    # helpers
+    # ------------------------------------------------------------------
+    def _setup_memory(self, meta: MemoryRetrievalMetadata) -> None:
+        tmpdir = tempfile.TemporaryDirectory()
+        memory_dir = tmpdir.name
+        meta["_tmpdir"] = tmpdir
+        meta["memory_dir"] = memory_dir
+        try:
+            data = json.loads(meta.get("static_memory", "{}"))
+            guideline = data.get("guideline")
+            if guideline:
+                os.makedirs(memory_dir, exist_ok=True)
+                with open(os.path.join(memory_dir, "guideline.md"), "w") as f:
+                    f.write(guideline)
+            user_path = data.get("user_file_path")
+            user_content = data.get("user_file_content", "")
+            if user_path:
+                full = os.path.join(memory_dir, user_path)
+                os.makedirs(os.path.dirname(full), exist_ok=True)
+                with open(full, "w") as f:
+                    f.write(user_content)
+        except Exception:
+            pass
+
+    # ------------------------------------------------------------------
+    def step(
+        self,
+        message_log_batch: list[list[dict[str, str]]],
+        metadata_batch: list[MemoryRetrievalMetadata],
+    ) -> EnvironmentReturn:
+        observations: list[dict[str, str]] = []
+        rewards: list[float] = []
+        terminateds: list[bool] = []
+        next_stop_strings: list[Optional[list[str]] | None] = []
+        next_metadata: list[Optional[MemoryRetrievalMetadata]] = []
+
+        for message_log, meta in zip(message_log_batch, metadata_batch):
+            meta = dict(meta) if meta is not None else {}
+            if "memory_dir" not in meta:
+                self._setup_memory(meta)
+                meta["num_turns"] = 0
+            memory_dir = meta["memory_dir"]
+            num_turns = meta.get("num_turns", 0)
+
+            # find last assistant message
+            last = next((m["content"] for m in reversed(message_log) if m["role"] == "assistant"), "")
+            python_code = extract_python_code(last)
+            obs_content = ""
+            reward = 0.0
+            terminated = False
+            new_meta: Optional[MemoryRetrievalMetadata] = meta.copy()
+
+            if python_code:
+                locals_dict, error = execute_sandboxed_code(
+                    python_code,
+                    timeout=SANDBOX_TIMEOUT,
+                    allowed_path=memory_dir,
+                    import_module="agent.tools",
+                )
+                result = error if error else locals_dict
+                obs_content = f"<result>{result}</result>"
+            else:
+                obs_content = ""
+
+            if "<reply>" in last and "</reply>" in last:
+                reply_text = extract_reply(last)
+                fact = Fact(fact_description=meta.get("answer", ""))
+                reward = get_reward(folder_dump_str=reply_text, facts_to_check=[fact])
+                terminated = True
+                if "_tmpdir" in meta:
+                    meta["_tmpdir"].cleanup()
+                new_meta = None
+            elif num_turns + 1 >= self.max_turns:
+                terminated = True
+                if "_tmpdir" in meta:
+                    meta["_tmpdir"].cleanup()
+                new_meta = None
+            else:
+                new_meta["num_turns"] = num_turns + 1
+
+            observations.append({"role": "environment", "content": obs_content})
+            rewards.append(reward)
+            terminateds.append(terminated)
+            next_stop_strings.append(None)
+            next_metadata.append(new_meta)
+
+        return EnvironmentReturn(
+            observations=observations,
+            metadata=next_metadata,
+            next_stop_strings=next_stop_strings,
+            rewards=torch.tensor(rewards, dtype=torch.float32),
+            terminateds=torch.tensor(terminateds, dtype=torch.bool),
+        )
+
+    def shutdown(self) -> None:
+        pass
+
+    def global_post_process_and_metrics(self, batch: BatchedDataDict) -> tuple[BatchedDataDict, dict]:
+        final_rewards = batch.get("total_reward", torch.tensor([0.0] * len(batch["idx"])))
+        success_rate = (final_rewards > 0).float().mean().item() if len(final_rewards) > 0 else 0.0
+        return batch, {"memory_retrieval_success_rate": success_rate}


### PR DESCRIPTION
## Summary
- add memory retrieval environment based on Obsidian agent
- add dataset loader for memory retrieval
- provide GRPO training script and config
- document how to run the training
- expose new environment and dataset in package

## Testing
- `ruff check --fix ...`
- `black ...`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'ray')*

------
https://chatgpt.com/codex/tasks/task_e_68598866d928832ab6453c0239b50726