### PR TITLE
Add validation split support for memory retrieval dataset

### DIFF
--- a/examples/configs/grpo_memory_retrieval.yaml
+++ b/examples/configs/grpo_memory_retrieval.yaml
@@ -98,6 +98,7 @@ policy:
 
 data:
   dataset_path: "dataset.json"
+  val_split_ratio: 0.1
   max_input_seq_length: ${policy.max_total_sequence_length}
   prompt_file: null
   system_prompt_file: null

--- a/nemo_rl/data/hf_datasets/memory_retrieval_dataset.py
+++ b/nemo_rl/data/hf_datasets/memory_retrieval_dataset.py
@@ -17,10 +17,18 @@ def _format(example: dict[str, Any]) -> dict[str, Any]:
 class MemoryRetrievalDataset:
     """Load a JSON dataset for the memory retrieval task."""
 
-    def __init__(self, path: str):
+    def __init__(self, path: str, val_split_ratio: float | None = 0.1) -> None:
         ds = load_dataset("json", data_files=path)["train"]
-        formatted = ds.map(_format, remove_columns=ds.column_names)
-        self.formatted_ds = {"train": formatted, "validation": None}
+
+        if val_split_ratio is not None and val_split_ratio > 0:
+            split = ds.train_test_split(test_size=val_split_ratio, seed=42)
+            train_ds = split["train"].map(_format, remove_columns=ds.column_names)
+            val_ds = split["test"].map(_format, remove_columns=ds.column_names)
+        else:
+            train_ds = ds.map(_format, remove_columns=ds.column_names)
+            val_ds = None
+
+        self.formatted_ds = {"train": train_ds, "validation": val_ds}
         self.task_spec = TaskDataSpec(
             task_name="memory_retrieval",
             system_prompt_file="obsidian_agent/agent/system_prompt.txt",

--- a/run_memory_retrieval.py
+++ b/run_memory_retrieval.py
@@ -110,7 +110,10 @@ def setup_data(
     dict[str, EnvironmentInterface],
 ]:
     print("\n▶ Setting up data...")
-    dataset_obj = MemoryRetrievalDataset(data_config["dataset_path"])
+    dataset_obj = MemoryRetrievalDataset(
+        data_config["dataset_path"],
+        data_config.get("val_split_ratio", 0.1),
+    )
     task_spec = dataset_obj.task_spec
 
     task_data_processors: dict[str, tuple[TaskDataSpec, TaskDataProcessFnCallable]] = {
@@ -135,6 +138,14 @@ def setup_data(
     )
 
     val_dataset = None
+    if dataset_obj.formatted_ds.get("validation") is not None:
+        val_dataset = AllTaskProcessedDataset(
+            dataset_obj.formatted_ds["validation"],
+            tokenizer,
+            task_spec,
+            task_data_processors,
+            max_seq_length=data_config["max_input_seq_length"],
+        )
 
     task_to_env: dict[str, EnvironmentInterface] = defaultdict(lambda: env)
     task_to_env["memory_retrieval"] = env


### PR DESCRIPTION
## Summary
- support a validation split for `MemoryRetrievalDataset`
- expose `val_split_ratio` in the example GRPO config
- create validation dataset in `run_memory_retrieval.py`

## Testing
- `make run-training` *(fails: No virtual environment found)*
- `python run_memory_retrieval.py --config examples/configs/grpo_memory_retrieval.yaml` *(fails: ModuleNotFoundError: No module named 'ray')*

------
https://chatgpt.com/codex/tasks/task_e_68599e619a98832a911a8c18436c75b2